### PR TITLE
Added Book Meta, Skull Meta and Spigot Methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@
 # Ignore wiki if placed in the root directory
 /wiki
 /MockBukkit.wiki
+
+#IDE Specific
+/out
+*.iml

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 }
 
 dependencies {
-	compile 'org.bukkit:bukkit:1.8.8-R0.1-SNAPSHOT'
+	//compile 'org.bukkit:bukkit:1.8.8-R0.1-SNAPSHOT'
 	compile 'org.spigotmc:spigot-api:1.8.8-R0.1-SNAPSHOT'
 	compile 'junit:junit:4.12'
 	compile 'org.apache.commons:commons-io:1.3.2'

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -1,26 +1,19 @@
 package be.seeseemelk.mockbukkit;
 
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.logging.Level;
-import java.util.logging.LogManager;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
-
+import be.seeseemelk.mockbukkit.command.CommandResult;
+import be.seeseemelk.mockbukkit.command.ConsoleCommandSenderMock;
+import be.seeseemelk.mockbukkit.command.MessageTarget;
+import be.seeseemelk.mockbukkit.entity.EntityMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMockFactory;
+import be.seeseemelk.mockbukkit.inventory.ChestInventoryMock;
+import be.seeseemelk.mockbukkit.inventory.InventoryMock;
+import be.seeseemelk.mockbukkit.inventory.ItemFactoryMock;
+import be.seeseemelk.mockbukkit.inventory.PlayerInventoryMock;
+import be.seeseemelk.mockbukkit.plugin.PluginManagerMock;
+import be.seeseemelk.mockbukkit.scheduler.BukkitSchedulerMock;
+import be.seeseemelk.mockbukkit.scoreboard.ScoreboardManagerMock;
+import com.avaje.ebean.config.ServerConfig;
 import org.bukkit.BanEntry;
 import org.bukkit.BanList;
 import org.bukkit.BanList.Type;
@@ -51,21 +44,26 @@ import org.bukkit.plugin.ServicesManager;
 import org.bukkit.plugin.messaging.Messenger;
 import org.bukkit.util.CachedServerIcon;
 
-import com.avaje.ebean.config.ServerConfig;
-
-import be.seeseemelk.mockbukkit.command.CommandResult;
-import be.seeseemelk.mockbukkit.command.ConsoleCommandSenderMock;
-import be.seeseemelk.mockbukkit.command.MessageTarget;
-import be.seeseemelk.mockbukkit.entity.EntityMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMockFactory;
-import be.seeseemelk.mockbukkit.inventory.ChestInventoryMock;
-import be.seeseemelk.mockbukkit.inventory.InventoryMock;
-import be.seeseemelk.mockbukkit.inventory.ItemFactoryMock;
-import be.seeseemelk.mockbukkit.inventory.PlayerInventoryMock;
-import be.seeseemelk.mockbukkit.plugin.PluginManagerMock;
-import be.seeseemelk.mockbukkit.scheduler.BukkitSchedulerMock;
-import be.seeseemelk.mockbukkit.scoreboard.ScoreboardManagerMock;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 @SuppressWarnings("deprecation")
 public class ServerMock implements Server
@@ -984,15 +982,13 @@ public class ServerMock implements Server
 	}
 
 	@Override
-	public CachedServerIcon loadServerIcon(File file) throws IllegalArgumentException, Exception
-	{
+	public CachedServerIcon loadServerIcon(File file) {
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
 	}
 
 	@Override
-	public CachedServerIcon loadServerIcon(BufferedImage image) throws IllegalArgumentException, Exception
-	{
+	public CachedServerIcon loadServerIcon(BufferedImage image) {
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
 	}
@@ -1022,6 +1018,11 @@ public class ServerMock implements Server
 	public UnsafeValues getUnsafe()
 	{
 		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public Spigot spigot() {
 		throw new UnimplementedOperationException();
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
@@ -1,15 +1,7 @@
 package be.seeseemelk.mockbukkit;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
+import be.seeseemelk.mockbukkit.block.BlockMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import org.bukkit.BlockChangeDelegate;
 import org.bukkit.Chunk;
 import org.bukkit.ChunkSnapshot;
@@ -40,8 +32,15 @@ import org.bukkit.metadata.MetadataValue;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.util.Vector;
 
-import be.seeseemelk.mockbukkit.block.BlockMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * A mock world object. Note that it is made to be as simple as possible. It is
@@ -991,8 +990,13 @@ public class WorldMock implements World
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
 	}
-	
-	@Override
+
+    @Override
+    public Spigot spigot() {
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
 	public WorldBorder getWorldBorder()
 	{
 		// TODO Auto-generated method stub

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -1,17 +1,12 @@
 package be.seeseemelk.mockbukkit.entity;
 
-import static org.junit.Assert.assertEquals;
-
-import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.EnumMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import be.seeseemelk.mockbukkit.inventory.PlayerInventoryMock;
+import be.seeseemelk.mockbukkit.inventory.PlayerInventoryViewMock;
+import be.seeseemelk.mockbukkit.inventory.SimpleInventoryViewMock;
+import com.google.common.base.Charsets;
+import com.google.common.base.Function;
 import org.bukkit.Achievement;
 import org.bukkit.BanList;
 import org.bukkit.Bukkit;
@@ -55,14 +50,17 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.util.Vector;
 
-import com.google.common.base.Charsets;
-import com.google.common.base.Function;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.UnimplementedOperationException;
-import be.seeseemelk.mockbukkit.inventory.PlayerInventoryMock;
-import be.seeseemelk.mockbukkit.inventory.PlayerInventoryViewMock;
-import be.seeseemelk.mockbukkit.inventory.SimpleInventoryViewMock;
+import static org.junit.Assert.assertEquals;
 
 public class PlayerMock extends EntityMock implements Player
 {
@@ -1421,8 +1419,13 @@ public class PlayerMock extends EntityMock implements Player
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
 	}
-	
-	@Override
+
+    @Override
+    public Player.Spigot spigot() {
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
 	public List<Block> getLineOfSight(HashSet<Byte> transparent, int maxDistance)
 	{
 		// TODO Auto-generated method stub

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/SimpleEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/SimpleEntityMock.java
@@ -1,5 +1,7 @@
 package be.seeseemelk.mockbukkit.entity;
 
+import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+
 import java.util.UUID;
 
 /**
@@ -26,5 +28,10 @@ public class SimpleEntityMock extends EntityMock
 	public SimpleEntityMock()
 	{
 		this(UUID.randomUUID());
+	}
+
+	@Override
+	public Spigot spigot() {
+		throw new UnimplementedOperationException();
 	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/ItemFactoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/ItemFactoryMock.java
@@ -3,6 +3,7 @@ package be.seeseemelk.mockbukkit.inventory;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.inventory.meta.BookMetaMock;
 import be.seeseemelk.mockbukkit.inventory.meta.ItemMetaMock;
+import be.seeseemelk.mockbukkit.inventory.meta.SkullMetaMock;
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemFactory;
@@ -46,7 +47,7 @@ public class ItemFactoryMock implements ItemFactory
 			case SKULL:
 			case SKULL_ITEM:
 				// TODO Auto-generated method stub
-				throw new UnimplementedOperationException();
+				return SkullMetaMock.class;
 			case EGG:
 			case DRAGON_EGG:
 			case MONSTER_EGG:

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/ItemFactoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/ItemFactoryMock.java
@@ -1,16 +1,16 @@
 package be.seeseemelk.mockbukkit.inventory;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-
+import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import be.seeseemelk.mockbukkit.inventory.meta.BookMetaMock;
+import be.seeseemelk.mockbukkit.inventory.meta.ItemMetaMock;
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemFactory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
-import be.seeseemelk.mockbukkit.UnimplementedOperationException;
-import be.seeseemelk.mockbukkit.inventory.meta.ItemMetaMock;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 
 public class ItemFactoryMock implements ItemFactory
 {
@@ -24,8 +24,7 @@ public class ItemFactoryMock implements ItemFactory
 				// TODO Auto-generated method stub
 				throw new UnimplementedOperationException();
 			case BOOK:
-				// TODO Auto-generated method stub
-				throw new UnimplementedOperationException();
+				return BookMetaMock.class;
 			case ENCHANTED_BOOK:
 				// TODO Auto-generated method stub
 				throw new UnimplementedOperationException();
@@ -82,14 +81,7 @@ public class ItemFactoryMock implements ItemFactory
 	public boolean isApplicable(ItemMeta meta, Material material) throws IllegalArgumentException
 	{
 		Class<? extends ItemMeta> target = getItemMetaClass(material);
-		if (target.isInstance(meta))
-		{
-			return true;
-		}
-		else
-		{
-			return false;
-		}
+		return target.isInstance(meta);
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BookMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BookMetaMock.java
@@ -1,0 +1,134 @@
+package be.seeseemelk.mockbukkit.inventory.meta;
+
+import com.google.common.base.Strings;
+import org.apache.commons.lang.Validate;
+import org.bukkit.inventory.meta.BookMeta;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Created by SimplyBallistic on 26/10/2018
+ *
+ * @author SimplyBallistic
+ **/
+public class BookMetaMock extends ItemMetaMock implements BookMeta {
+    private String title;
+    private List<String> pages = new ArrayList<>();
+    private String author;
+
+    @Override
+    public boolean hasTitle() {
+        return !Strings.isNullOrEmpty(this.title);
+    }
+
+    @Override
+    public boolean hasPages() {
+        return !this.pages.isEmpty();
+    }
+
+    @Override
+    public String getTitle() {
+        return this.title;
+    }
+
+    @Override
+    public boolean setTitle(String title) {
+        if (title == null) {
+            this.title = null;
+            return true;
+        } else if (title.length() > 65535) {
+            return false;
+        } else {
+            this.title = title;
+            return true;
+        }
+    }
+
+    @Override
+    public boolean hasAuthor() {
+        return !Strings.isNullOrEmpty(this.author);
+    }
+
+    @Override
+    public String getAuthor() {
+        return author;
+    }
+
+    @Override
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    @Override
+    public String getPage(int page) {
+        Validate.isTrue(this.isValidPage(page), "Invalid page number");
+        return this.pages.get(page - 1);
+    }
+
+    private boolean isValidPage(int page) {
+        return page > 0 && page <= this.pages.size();
+    }
+
+    @Override
+    public void setPage(int page, String text) {
+        if (!this.isValidPage(page)) {
+            throw new IllegalArgumentException("Invalid page number " + page + "/" + this.pages.size());
+        } else {
+            String newText = text == null ? "" : (text.length() > 32767 ? text.substring(0, 32767) : text);
+            this.pages.set(page - 1, newText);
+        }
+    }
+
+    @Override
+    public List<String> getPages() {
+        return null;
+    }
+
+    @Override
+    public void setPages(String... pages) {
+        this.pages.clear();
+        this.addPage(pages);
+    }
+
+    @Override
+    public void setPages(List<String> pages) {
+        this.pages.clear();
+        Iterator var2 = pages.iterator();
+
+        while (var2.hasNext()) {
+            String page = (String) var2.next();
+            this.addPage(page);
+        }
+
+    }
+
+    @Override
+    public void addPage(String... pages) {
+
+        for (String page1 : pages) {
+            String page = page1;
+            if (page == null) {
+                page = "";
+            } else if (page.length() > 32767) {
+                page = page.substring(0, 32767);
+            }
+
+            this.pages.add(page);
+        }
+
+    }
+
+    @Override
+    public int getPageCount() {
+        return this.pages.size();
+    }
+
+    @Override
+    public BookMetaMock clone() {
+        BookMetaMock mock = new BookMetaMock();
+        mock.pages = new ArrayList<>(pages);
+        return mock;
+    }
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -123,7 +123,7 @@ public class ItemMetaMock implements ItemMeta
 	}
 
 	@Override
-	public ItemMetaMock clone()
+	public ItemMeta clone()
 	{
 		try
 		{

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -8,6 +8,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -19,6 +20,7 @@ public class ItemMetaMock implements ItemMeta
 	private String displayName = null;
 	private List<String> lore = null;
     private Map<Enchantment, Integer> enchantments = null;
+    private int hideFlag;
 	public ItemMetaMock()
 	{
 
@@ -262,33 +264,43 @@ public class ItemMetaMock implements ItemMeta
 	}
 
 	@Override
-	public void addItemFlags(ItemFlag... itemFlags)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+    public void addItemFlags(ItemFlag... hideFlags) {
+
+        for (ItemFlag f : hideFlags) {
+            this.hideFlag |= this.getBitModifier(f);
+        }
+
 	}
 
-	@Override
-	public void removeItemFlags(ItemFlag... itemFlags)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+    public void removeItemFlags(ItemFlag... hideFlags) {
+
+        for (ItemFlag f : hideFlags) {
+            this.hideFlag &= ~this.getBitModifier(f);
+        }
+
 	}
 
-	@Override
-	public Set<ItemFlag> getItemFlags()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
+    public Set<ItemFlag> getItemFlags() {
+        Set<ItemFlag> currentFlags = EnumSet.noneOf(ItemFlag.class);
+        ItemFlag[] enumValues = ItemFlag.values();
 
-	@Override
-	public boolean hasItemFlag(ItemFlag flag)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
+        for (ItemFlag f : enumValues) {
+            if (this.hasItemFlag(f)) {
+                currentFlags.add(f);
+            }
+        }
 
+        return currentFlags;
+    }
+
+    public boolean hasItemFlag(ItemFlag flag) {
+        int bitModifier = this.getBitModifier(flag);
+        return (this.hideFlag & bitModifier) == bitModifier;
+    }
+
+    private byte getBitModifier(ItemFlag hideFlag) {
+        return (byte) (1 << hideFlag.ordinal());
+    }
 	/**
 	 * Asserts if the lore contains the given lines in order.
 	 *

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -1,6 +1,7 @@
 package be.seeseemelk.mockbukkit.inventory.meta;
 
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import com.google.common.collect.ImmutableMap;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -233,7 +234,7 @@ public class ItemMetaMock implements ItemMeta
 	@Override
 	public Map<Enchantment, Integer> getEnchants()
 	{
-        return enchantments;
+        return hasEnchants() ? ImmutableMap.copyOf(enchantments) : ImmutableMap.of();
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -292,6 +292,20 @@ public class ItemMetaMock implements ItemMeta
 
 	}
 
+    public class Spigot extends ItemMeta.Spigot {
+        private boolean unbreakable;
+
+        @Override
+        public boolean isUnbreakable() {
+            return unbreakable;
+        }
+
+        @Override
+        public void setUnbreakable(boolean unbreakable) {
+            this.unbreakable = unbreakable;
+        }
+    }
+
 }
 
 

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -1,16 +1,15 @@
 package be.seeseemelk.mockbukkit.inventory.meta;
 
+import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.meta.ItemMeta;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import org.bukkit.enchantments.Enchantment;
-import org.bukkit.inventory.ItemFlag;
-import org.bukkit.inventory.meta.ItemMeta;
-
-import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 
 public class ItemMetaMock implements ItemMeta
 {
@@ -151,10 +150,12 @@ public class ItemMetaMock implements ItemMeta
 	{
 		this.lore = new ArrayList<>(lore);
 	}
-	
+
+	private Spigot spigot;
+
 	/**
 	 * Asserts if the lore contains the given lines in order.
-	 * @param lines The lines the lore should contain 
+	 * @param lines The lines the lore should contain
 	 */
 	public void assertLore(List<String> lines)
 	{
@@ -176,15 +177,6 @@ public class ItemMetaMock implements ItemMeta
 		{
 			throw new AssertionError("No lore was set");
 		}
-	}
-
-	/**
-	 * Asserts if the lore contains the given lines in order.
-	 * @param lines The lines the lore should contain 
-	 */
-	public void assertLore(String... lines)
-	{
-		assertLore(Arrays.asList(lines));
 	}
 
 	@Override
@@ -270,18 +262,34 @@ public class ItemMetaMock implements ItemMeta
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
 	}
-	
+
+	/**
+	 * Asserts if the lore contains the given lines in order.
+	 *
+	 * @param lines The lines the lore should contain
+	 */
+	public void assertLore(String... lines) {
+		assertLore(Arrays.asList(lines));
+	}
+
 	/**
 	 * Asserts that the item meta contains no lore.
-	 * 
+	 *
 	 * @throws AssertionError if the item meta contains some lore.
 	 */
-	public void assertHasNoLore() throws AssertionError
-	{
-		if (lore != null && lore.size() != 0)
-		{
+	public void assertHasNoLore() throws AssertionError {
+		if (lore != null && lore.size() != 0) {
 			throw new AssertionError("Lore was set but shouldn't have been set");
 		}
+	}
+
+	@Override
+	public Spigot spigot() {
+		if (spigot == null)
+			spigot = new Spigot();
+
+		return spigot;
+
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMock.java
@@ -1,0 +1,36 @@
+package be.seeseemelk.mockbukkit.inventory.meta;
+
+import jdk.internal.joptsimple.internal.Strings;
+import org.bukkit.inventory.meta.SkullMeta;
+
+/**
+ * Created by SimplyBallistic on 27/10/2018
+ *
+ * @author SimplyBallistic
+ **/
+public class SkullMetaMock extends ItemMetaMock implements SkullMeta {
+    private String owner;
+
+    @Override
+    public String getOwner() {
+        return owner;
+    }
+
+    @Override
+    public boolean hasOwner() {
+        return !Strings.isNullOrEmpty(owner);
+    }
+
+    @Override
+    public boolean setOwner(String owner) {
+        this.owner = owner;
+        return true;
+    }
+
+    @Override
+    public SkullMeta clone() {
+        SkullMetaMock mock = new SkullMetaMock();
+        mock.setOwner(owner);
+        return mock;
+    }
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMock.java
@@ -1,6 +1,6 @@
 package be.seeseemelk.mockbukkit.inventory.meta;
 
-import jdk.internal.joptsimple.internal.Strings;
+import com.google.common.base.Strings;
 import org.bukkit.inventory.meta.SkullMeta;
 
 /**

--- a/src/main/java/be/seeseemelk/mockbukkit/scoreboard/ScoreMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scoreboard/ScoreMock.java
@@ -60,6 +60,11 @@ public class ScoreMock implements Score
 	}
 
 	@Override
+	public boolean isScoreSet() throws IllegalStateException {
+		return false;
+	}
+
+	@Override
 	public Scoreboard getScoreboard()
 	{
 		return objective.getScoreboard();

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/BookMetaMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/BookMetaMockTest.java
@@ -1,0 +1,10 @@
+package be.seeseemelk.mockbukkit.inventory.meta;
+
+/**
+ * Created by SimplyBallistic on 26/10/2018
+ *
+ * @author SimplyBallistic
+ **/
+public class BookMetaMockTest {
+    //TODO
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMockTest.java
@@ -1,22 +1,21 @@
 package be.seeseemelk.mockbukkit.inventory.meta;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ItemMetaMockTest
 {
 	private ItemMetaMock meta;
 
 	@Before
-	public void setUp() throws Exception
-	{
+	public void setUp() {
 		meta = new ItemMetaMock();
 	}
 
@@ -130,7 +129,7 @@ public class ItemMetaMockTest
 	public void clone_WithDisplayName_ClonedExactly()
 	{
 		meta.setDisplayName("Some name");
-		ItemMetaMock cloned = meta.clone();
+		ItemMetaMock cloned = (ItemMetaMock) meta.clone();
 		assertEquals(meta, cloned);
 		assertEquals(meta.hashCode(), cloned.hashCode());
 	}


### PR DESCRIPTION
I first forked to fit my small use case, but ended up expanding it to a point where it *maybe* might help someone. 
Changes made: 
- Made a separate spigot branch for spigot methods. I cannot create a branch through a pull request, so I recommend you handle this yourself. This was also done for 1.13. You can view the changes under [https://github.com/SimplyBallistic/MockBukkit/tree/v1.13-spigot](url)
- Added BookMockMeta
- Added SkullMockMeta
- Supported almost all (maybe all of them, don't remember) ItemMockMeta methods including enchants, flags etc. 
- TODO bookmeta test, one probably needed for skull meta, enchants and new itemmeta methods too to fit into your very long list of tests (gotta say, very satisfying to run them all)

Make sure to shuffle the branches around or edit this pull request itself if need be. 

You also might need to do a little cherrypicking to make sure all branch versions get a taste of these changes. I tried to make the commits as modular as possible to suit this case. 

I hope you find this contribution helpful. 
You helped make my obsession of Unit tests expand to the likes of MC :) 
