### PR TITLE
Implement isPluginEnabled() methods

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
@@ -505,15 +505,33 @@ public class PluginManagerMock implements PluginManager
 	@Override
 	public boolean isPluginEnabled(String name)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		boolean result = false;
+
+		for (Plugin mockedPlugin : plugins)
+		{
+			if (mockedPlugin.getName().equals(name))
+			{
+				result = mockedPlugin.isEnabled();
+			}
+		}
+
+		return result;
 	}
 	
 	@Override
 	public boolean isPluginEnabled(Plugin plugin)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		boolean result = false;
+
+		for (Plugin mockedPlugin : plugins)
+		{
+			if (mockedPlugin.equals(plugin))
+			{
+				result = plugin.isEnabled();
+			}
+		}
+
+		return result;
 	}
 	
 	@Override


### PR DESCRIPTION
By looping through all mocked plugins and checking if the plugin (name) matches and if it is enabled.