### PR TITLE
Allow adding non-blank mock worlds to mock server

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -271,6 +271,17 @@ public class ServerMock implements Server
 	}
 	
 	/**
+	 * Adds the given mocked world to this server.
+	 *
+	 * @param world The world to add.
+	 */
+	public void addWorld(WorldMock world)
+	{
+		assertMainThread();
+		worlds.add(world);
+	}
+	
+	/**
 	 * Executes a command as the console.
 	 * 
 	 * @param command The command to execute.


### PR DESCRIPTION
Currently, if a mock world is created by means other than MockServer.addSimpleWorld it is not registered as a world on the mock server. This means MockServer.getWorld(name) does not find it, causing potential issues for some test cases.