### PR TITLE
Implements UnsafeValues#getDataVersion

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
@@ -51,7 +51,7 @@ public class MockUnsafeValues implements UnsafeValues
 	public int getDataVersion()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return 1;
 	}
 	
 	@Override


### PR DESCRIPTION
This commit simply implements the data version method in the
UnsafeValues mock to allow ItemStacks being serialized.

This PR should fix #18 