### PR TITLE
Fixed EntityDamageEvent changing damage not being taken into account

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -317,6 +317,7 @@ public class PlayerMock extends EntityMock implements Player
 		Bukkit.getPluginManager().callEvent(event);
 		if (!event.isCancelled())
 		{
+			amount = event.getDamage();
 			setHealth(health - amount);
 		}
 	}
@@ -335,6 +336,7 @@ public class PlayerMock extends EntityMock implements Player
 		Bukkit.getPluginManager().callEvent(event);
 		if (!event.isCancelled())
 		{
+			amount = event.getDamage();
 			setHealth(health - amount);
 		}
 	}


### PR DESCRIPTION
I did not know how to add an event to the unit test. But I did test it in another project I'm working on, and it is producing  correct results.

This is the Test I'm using:
```Java
@Test
    public void playerDamagePlayerCustomItem(){
        double healthDifference = 20; // This is:
        PlayerMock player1 = server.addPlayer("Tatan");
        double initialHealth = player1.getHealth();
        PlayerMock player2 = server.addPlayer("John");

        ItemStack customItem = plugin.getCustomItems().get("w_redlightsaber").toItemStack();
        player2.setItemInHand(customItem);
        player1.damage(4, player2); //4 is just a random integer. Can be anything.

        double finalHealth = player1.getHealth();
        Assert.assertEquals(initialHealth-finalHealth, healthDifference,0.1);
    }

Which calls this event, the output of the damage is 30, where PlayerMock sets the player health back to 0:
```Java
@EventHandler(priority = EventPriority.HIGH)
    public void onPlayerDamage(EntityDamageByEntityEvent event){
        if(event.getDamager() instanceof Player){
            Player damager = (Player) event.getDamager();
            if(event.getEntity() instanceof Player){
                Player playerDamaged = (Player) event.getEntity();
                double damage = playerDamagePlayer(damager, playerDamaged);
                if(damage > 0) {
                    event.setDamage(damage);
                } else {
                    damage = event.getDamage();
                }
                System.out.println(damager.getDisplayName()+" damaged "+
                        playerDamaged.getDisplayName()+" for "+damage);
            }
        }
    }
```