### PR TITLE
Add ServerMock#joinPlayer methods

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -163,9 +163,29 @@ public class ServerMock implements Server
 		assertMainThread();
 		players.add(player);
 		offlinePlayers.add(player);
+		registerEntity(player);
+	}
+	
+	/**
+	 * Adds a player and fires a join event.
+	 * @param player The player to add.
+	 */
+	public void joinPlayer(PlayerMock player)
+	{
+		addPlayer(player);
 		PlayerJoinEvent playerJoinEvent = new PlayerJoinEvent(player, String.format(JOIN_MESSAGE, player.getDisplayName()));
 		Bukkit.getPluginManager().callEvent(playerJoinEvent);
-		registerEntity(player);
+	}
+	
+	/**
+	 * Adds a random player and fires a join event.
+	 * @param player The player to add.
+	 */
+	public PlayerMock joinPlayer()
+	{
+		PlayerMock player = playerFactory.createRandomPlayer();
+		joinPlayer(player);
+		return player;
 	}
 
 	/**

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -22,6 +22,7 @@ import org.bukkit.Material;
 import org.bukkit.command.Command;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
@@ -69,8 +70,10 @@ public class ServerMockTest
 		
 		server.addPlayer(player1);
 		assertEquals(1, server.getOnlinePlayers().size());
+		server.getPluginManager().assertEventFired(PlayerJoinEvent.class, event -> event.getPlayer().equals(player1));
 		server.addPlayer(player2);
 		assertEquals(2, server.getOnlinePlayers().size());
+		server.getPluginManager().assertEventFired(PlayerJoinEvent.class, event -> event.getPlayer().equals(player2));
 		
 		assertEquals(player1, server.getPlayer(0));
 		assertEquals(player2, server.getPlayer(1));
@@ -84,7 +87,9 @@ public class ServerMockTest
 	public void addPlayers_None_TwoUniquePlayers()
 	{
 		PlayerMock playerA = server.addPlayer();
+		server.getPluginManager().assertEventFired(PlayerJoinEvent.class, event -> event.getPlayer().equals(playerA));
 		PlayerMock playerB = server.addPlayer();
+		server.getPluginManager().assertEventFired(PlayerJoinEvent.class, event -> event.getPlayer().equals(playerB));
 		PlayerMock player1 = server.getPlayer(0);
 		PlayerMock player2 = server.getPlayer(1);
 		assertNotNull(player1);

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -70,10 +70,8 @@ public class ServerMockTest
 		
 		server.addPlayer(player1);
 		assertEquals(1, server.getOnlinePlayers().size());
-		server.getPluginManager().assertEventFired(PlayerJoinEvent.class, event -> event.getPlayer().equals(player1));
 		server.addPlayer(player2);
 		assertEquals(2, server.getOnlinePlayers().size());
-		server.getPluginManager().assertEventFired(PlayerJoinEvent.class, event -> event.getPlayer().equals(player2));
 		
 		assertEquals(player1, server.getPlayer(0));
 		assertEquals(player2, server.getPlayer(1));
@@ -87,9 +85,7 @@ public class ServerMockTest
 	public void addPlayers_None_TwoUniquePlayers()
 	{
 		PlayerMock playerA = server.addPlayer();
-		server.getPluginManager().assertEventFired(PlayerJoinEvent.class, event -> event.getPlayer().equals(playerA));
 		PlayerMock playerB = server.addPlayer();
-		server.getPluginManager().assertEventFired(PlayerJoinEvent.class, event -> event.getPlayer().equals(playerB));
 		PlayerMock player1 = server.getPlayer(0);
 		PlayerMock player2 = server.getPlayer(1);
 		assertNotNull(player1);
@@ -97,6 +93,27 @@ public class ServerMockTest
 		assertEquals(playerA, player1);
 		assertEquals(playerB, player2);
 		assertNotEquals(player1, player2);
+	}
+	
+	@Test
+	public void joinPlayer_APlayer_PlayerAddedAndEventFired()
+	{
+		PlayerMockFactory factory = new PlayerMockFactory(server);
+		PlayerMock player = factory.createRandomPlayer();
+		
+		server.joinPlayer(player);
+		server.getPluginManager().assertEventFired(PlayerJoinEvent.class, event -> event.getPlayer().equals(player)); 
+		assertTrue("Player was not registered", server.getEntities().contains(player));
+	}
+	
+	@Test
+	public void joinPlayers_None_TwoUniquePlayers()
+	{
+		PlayerMock player = server.joinPlayer();
+		server.getPluginManager().assertEventFired(PlayerJoinEvent.class, event -> event.getPlayer().equals(player));
+		PlayerMock addedPlayer = server.getPlayer(0);
+		assertNotNull(player);
+		assertEquals(player, addedPlayer);
 	}
 	
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -694,11 +694,4 @@ public class PlayerMockTest
 		assertTrue(player.isSneaking());
 	}
 
-	@Test
-	public void dispatchPlayer_PlayerJoinEventFired() {
-		PlayerMock player = server.addPlayer();
-		PluginManagerMock pluginManager = server.getPluginManager();
-		pluginManager.assertEventFired(event -> event instanceof PlayerJoinEvent);
-	}
-
 }


### PR DESCRIPTION
This pull request makes the `ServerMock#addPlayer` not fire a `PlayerJoinEvent` anymore.
However, it also adds the `ServerMock#joinPlayer` methods. These methods are similar to the `ServerMock#addPlayer` methods, except that they do fire a `PlayerJoinEvent`.