### PR TITLE
Fix lower case issues

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -420,7 +420,7 @@ public class ServerMock implements Server
 	public Player getPlayerExact(String name)
 	{
 		assertMainThread();
-		return this.players.stream().filter(playerMock -> playerMock.getName().equals(name)).findFirst().orElse(null);
+		return this.players.stream().filter(playerMock -> playerMock.getName().toLowerCase(Locale.ENGLISH).equals(name.toLowerCase(Locale.ENGLISH))).findFirst().orElse(null);
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -428,7 +428,7 @@ public class ServerMock implements Server
 	{
 		assertMainThread();
 		return players.stream()
-				.filter(player -> player.getName().toLowerCase(Locale.ENGLISH).startsWith(name.toLowerCase()))
+				.filter(player -> player.getName().toLowerCase(Locale.ENGLISH).startsWith(name.toLowerCase(Locale.ENGLISH)))
 				.collect(Collectors.toList());
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -427,13 +427,13 @@ public class ServerMockTest
 		server.addPlayer(player);
 		assertSame(player, server.getPlayerExact("player"));
 	}
-	
+
 	@Test
-	public void getPlayerExact_CasingDoesNotMatch_PlayerNotFoundFound()
+	public void getPlayerExact_CasingDoesNotMatch_PlayerFound()
 	{
 		PlayerMock player = new PlayerMock(server, "player");
 		server.addPlayer(player);
-		assertNull(server.getPlayerExact("PLAYER"));
+		assertNotNull(server.getPlayerExact("PLAYER"));
 	}
 	
 	@Test


### PR DESCRIPTION
`getPlayerExact` was not properly emulating craftbukkit, craftbukkit makes search of player names explicitly case-insensitive.

`matchPlayer` could potentially have a bug regarding Locale where one side had been `toLowerCase`'d with a different `Locale` compared to the other.