### PR TITLE
Implement some Eye related functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add CHANGELOG.md
+- Implement `Player#getEyeLocation`, `Player#getEyeHeight()`, and `Player#getEyeHeight(boolean)`
 
 ### Fixed
 - Out-of-date maven dependency information in README

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -208,8 +208,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	@Override
 	public Location getEyeLocation()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return getLocation().add(0, getEyeHeight(), 0);
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -437,22 +437,20 @@ public class PlayerMock extends LivingEntityMock implements Player
 	@Override
 	public double getEyeHeight()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return getEyeHeight(false);
 	}
 
 	@Override
 	public double getEyeHeight(boolean ignorePose)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		if (isSneaking() && !ignorePose) return 1.54D;
+		return 1.62D;
 	}
 
 	@Override
 	public Location getEyeLocation()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return getLocation().add(0, getEyeHeight(), 0);
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -448,12 +448,6 @@ public class PlayerMock extends LivingEntityMock implements Player
 	}
 
 	@Override
-	public Location getEyeLocation()
-	{
-		return getLocation().add(0, getEyeHeight(), 0);
-	}
-
-	@Override
 	public List<Block> getLineOfSight(Set<Material> transparent, int maxDistance)
 	{
 		// TODO Auto-generated method stub

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -2,6 +2,7 @@ package be.seeseemelk.mockbukkit.entity;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -693,6 +693,17 @@ public class PlayerMockTest
 		player.setSneaking(true);
 		assertTrue(player.isSneaking());
 	}
+	
+	@Test
+	public void getPlayer_SneakingEyeHeight() {
+		player.setSneaking(true);
+		assertNotEquals(player.getEyeHeight(), player.getEyeHeight(true));
+	}
+	
+	@Test
+	public void getPlayer_EyeLocationDiffers(){
+		assertNotEquals(player.getEyeLocation(), player.getLocation());
+	}
 
 	@Test
 	public void dispatchPlayer_PlayerJoinEventFired() {


### PR DESCRIPTION
Defaults to standard Bukkit player height, is changed by sneaking. Tests to verify all pass on my end, though I'd love it if someone could independently verify these constants on various server versions. Eventually we should use the headHeight rather than constants, but for now this is good.